### PR TITLE
Use future>=0.14.0 so 'html' is available in Python 2.7.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added missing requires `html`.
 
 
 2.0.0 (2017-04-17)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 2.0.1 (unreleased)
 ------------------
 
-- Added missing requires `html`.
+- Required future>=0.14.0 so `html` package is available in Python 2.7.
 
 
 2.0.0 (2017-04-17)

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,7 @@ setup(
         ),
     install_requires=[
         'setuptools',
-        'future',
-        'html',
+        'future>=0.14.0',
         'z3c.batching>=1.1.0',
         'zope.component',
         'zope.contentprovider',

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ def read(*rnames):
 setup(
     name='z3c.table',
     version='2.0.1.dev0',
-    author = "Stephan Richter, Roger Ineichen and the Zope Community",
-    author_email = "zope-dev@zope.org",
-    description = "Modular table rendering implementation for Zope3",
+    author="Stephan Richter, Roger Ineichen and the Zope Community",
+    author_email="zope-dev@zope.org",
+    description="Modular table rendering implementation for Zope3",
     long_description=(
         read('README.txt')
         + '\n\n' +

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     install_requires=[
         'setuptools',
         'future',
+        'html',
         'z3c.batching>=1.1.0',
         'zope.component',
         'zope.contentprovider',


### PR DESCRIPTION
Hi,

new version fails to start on a fresh Plone because it misses the html requirement.

Could you please review and merge if OK?

By the way, could you have a look at the issue I posted months ago ;-)

Thank you!

Gauthier