### PR TITLE
escape special HTML chars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ CHANGES
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix: escape special HTML characters at ``Column.renderHeadCell``, 
+  ``NameColumn.getName``, ``CheckBoxColumn`` name and value,
+  ``RadioColumn`` name and value, ``LinkColumn`` href and link content.
 
 
 2.1 (2019-01-27)

--- a/src/z3c/table/interfaces.py
+++ b/src/z3c/table/interfaces.py
@@ -265,7 +265,10 @@ class IColumnHeader(zope.interface.Interface):
         """Override this method in subclasses if required"""
 
     def render():
-        """Override this method in subclasses"""
+        """Return the HTML output for the header
+
+        Make sure HTML special chars are escaped.
+        Override this method in subclasses"""
 
     def getQueryStringArgs():
         """

--- a/src/z3c/table/testing.py
+++ b/src/z3c/table/testing.py
@@ -20,7 +20,7 @@ import datetime
 import zope.interface
 import zope.component
 import zope.traversing.testing
-from zope.container import btree, ordered
+from zope.container import btree, contained, ordered
 from zope.dublincore.interfaces import IZopeDublinCore
 from zope.security import checker
 from zope.site.testing import siteSetUp, siteTearDown
@@ -62,7 +62,7 @@ class OrderedContainer(ordered.OrderedContainer):
     __name__ = u"container"
 
 
-class Content(object):
+class Content(contained.Contained):
     """Sample content."""
 
     def __init__(self, title, number):


### PR DESCRIPTION
I'm very tempted to add escape also to `GetAttrColumn.renderCell`, `GetItemColumn.renderCell` and `I18nGetAttrColumn.renderCell`

opinions? anyone?